### PR TITLE
fix: differentiate background for hovered menu items

### DIFF
--- a/templates/openbox.tera
+++ b/templates/openbox.tera
@@ -28,7 +28,7 @@ menu.items.bg.color:                                          #{{ base.hex }}
 menu.items.text.color:                                        #{{ text.hex }}
 
 menu.items.active.bg:                                      flat solid
-menu.items.active.bg.color:                                   #{{ base.hex }}
+menu.items.active.bg.color:                                   #{{ overlay2 | mix(color=base, amount=0.3) | get(key="hex") }}
 menu.items.active.text.color:                                 #{{ text.hex }}
 menu.items.disabled.text.color:                               #{{ overlay1.hex }}
 menu.items.active.disabled.text.color:                        #{{ overlay1.hex }}

--- a/themes/catppuccin-frappe/openbox-3/themerc
+++ b/themes/catppuccin-frappe/openbox-3/themerc
@@ -21,7 +21,7 @@ menu.items.bg.color:                                          #303446
 menu.items.text.color:                                        #c6d0f5
 
 menu.items.active.bg:                                      flat solid
-menu.items.active.bg.color:                                   #303446
+menu.items.active.bg.color:                                   #4f5369
 menu.items.active.text.color:                                 #c6d0f5
 menu.items.disabled.text.color:                               #838ba7
 menu.items.active.disabled.text.color:                        #838ba7

--- a/themes/catppuccin-latte/openbox-3/themerc
+++ b/themes/catppuccin-latte/openbox-3/themerc
@@ -21,7 +21,7 @@ menu.items.bg.color:                                          #eff1f5
 menu.items.text.color:                                        #4c4f69
 
 menu.items.active.bg:                                      flat solid
-menu.items.active.bg.color:                                   #eff1f5
+menu.items.active.bg.color:                                   #ccced7
 menu.items.active.text.color:                                 #4c4f69
 menu.items.disabled.text.color:                               #8c8fa1
 menu.items.active.disabled.text.color:                        #8c8fa1

--- a/themes/catppuccin-macchiato/openbox-3/themerc
+++ b/themes/catppuccin-macchiato/openbox-3/themerc
@@ -21,7 +21,7 @@ menu.items.bg.color:                                          #24273a
 menu.items.text.color:                                        #cad3f5
 
 menu.items.active.bg:                                      flat solid
-menu.items.active.bg.color:                                   #24273a
+menu.items.active.bg.color:                                   #454a5f
 menu.items.active.text.color:                                 #cad3f5
 menu.items.disabled.text.color:                               #8087a2
 menu.items.active.disabled.text.color:                        #8087a2

--- a/themes/catppuccin-mocha/openbox-3/themerc
+++ b/themes/catppuccin-mocha/openbox-3/themerc
@@ -21,7 +21,7 @@ menu.items.bg.color:                                          #1e1e2e
 menu.items.text.color:                                        #cdd6f4
 
 menu.items.active.bg:                                      flat solid
-menu.items.active.bg.color:                                   #1e1e2e
+menu.items.active.bg.color:                                   #414356
 menu.items.active.text.color:                                 #cdd6f4
 menu.items.disabled.text.color:                               #7f849c
 menu.items.active.disabled.text.color:                        #7f849c


### PR DESCRIPTION
Tested on https://github.com/labwc/labwc: without this change, it's not visible what menu item is selected, because the text and bg color is the same for active and inactive items.